### PR TITLE
up case processor retries to 10

### DIFF
--- a/rm-services.yml
+++ b/rm-services.yml
@@ -22,8 +22,9 @@ services:
       test: ["CMD", "find", "/tmp/case-processor-healthy", "-mmin", "-1"]
       interval: 60s
       timeout: 10s
-      retries: 4
+      retries: 10
       start_period: 45s
+
 
   uacqid:
     container_name: uacqid


### PR DESCRIPTION
# Motivation and Context
sometimes case processor failed to start up within 4 goes.  Set this to 10

# What has changed
4 became 10

# How to test?
Not easy to prove it works, tried 'make up' a few times,  does caseprocessor always end up running?
