### PR TITLE
migrate pubsub adapter to ssdc

### DIFF
--- a/rm-services.yml
+++ b/rm-services.yml
@@ -151,6 +151,31 @@ services:
       start_period: 50s
 
 
+  pubsub-adapter:
+    container_name: pubsubadapter
+    image: eu.gcr.io/ssdc-rm-ci/rm/ssdc-rm-pubsub-adapter
+    external_links:
+      - rabbitmq
+      - pubsub-emulator
+    environment:
+      - LOG_LEVEL=INFO
+      - RABBIT_USERNAME=guest
+      - RABBIT_PASSWORD=guest
+      - RABBIT_HOST=${RABBIT_HOST}
+      - RABBIT_PORT=${RABBIT_PORT}
+      - EQ_RECEIPT_PROJECT=${EQ_RECEIPT_PROJECT}
+      - READINESS_FILE_PATH=/tmp/ready
+      - PUBSUB_EMULATOR_HOST=${PUBSUB_EMULATOR_HOSTNAME}:${PUBSUB_EMULATOR_PORT}
+      - QUARANTINE_MESSAGE_URL=http://${EXCEPTIONMANAGER_HOST}:${EXCEPTIONMANAGER_PORT}/storeskippedmessage
+    restart: always
+    healthcheck:
+      test: sh -c "[ -f /tmp/ready ]"
+      interval: 10s
+      timeout: 10s
+      retries: 10
+      start_period: 50s
+
+
 networks:
   default:
     external:


### PR DESCRIPTION
# Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
We would like to migrate the pubsub adapter to SSDC

# What has changed
<!--- What code changes has been made -->
<!--- Has there been any refactoring -->
<!--- What tests have been written -->
Added the SSDC pubsub adapter to docker dev

# How to test?
<!--- Describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc. -->
<!--- Are there any automated tests that mean changes don't need to be manually changed -->
Build the ssdc pubsub adapter from the other pull request on this ticket and make up, run the acceptance tests using the branch on this ticket.
# Links
<!--- Add any links to issues (trello, github issues) -->
<!--- Links to any documentation -->
<!--- Links to any related PRs -->
https://trello.com/c/gdrW9gzU/2418-few-more-repos-to-migrate-pubsub-adapter-data-exporter-5
# Screenshots (if appropriate):