### PR TITLE
Deactivate UAC Action Rule

### DIFF
--- a/rabbitmq/definitions.json
+++ b/rabbitmq/definitions.json
@@ -115,6 +115,16 @@
       }
     },
     {
+      "name": "events.caseProcessor.deactivateUac",
+      "vhost": "/",
+      "durable": true,
+      "auto_delete": false,
+      "arguments": {
+        "x-dead-letter-exchange": "delayedRedeliveryExchange",
+        "x-dead-letter-routing-key": "events.caseProcessor.deactivateUac"
+      }
+    },
+    {
       "name": "DelayedRedeliveryQueue",
       "vhost": "/",
       "durable": true,
@@ -226,6 +236,15 @@
       "destination": "events.caseProcessor.surveyLaunched",
       "destination_type": "queue",
       "routing_key": "events.caseProcessor.surveyLaunched",
+      "arguments": {
+      }
+    },
+    {
+      "source": "events",
+      "vhost": "/",
+      "destination": "events.caseProcessor.deactivateUac",
+      "destination_type": "queue",
+      "routing_key": "events.caseProcessor.deactivateUac",
       "arguments": {
       }
     },


### PR DESCRIPTION
# Motivation and Context
We need to be able to deactivate UACs on a certain date, when we no longer want to allow respondents to launch EQ.

# What has changed
Added new queue & routing

# How to test?
Run ATs.

Set up an action rule of type `DEACTIVATE_UAC`.

# Links
Trello: https://trello.com/c/MvZRwX7P