### PR TITLE
Make routing keys consistent

### DIFF
--- a/rabbitmq/definitions.json
+++ b/rabbitmq/definitions.json
@@ -183,7 +183,16 @@
       "vhost": "/",
       "destination": "events.caseProcessor.updateSampleSensitive",
       "destination_type": "queue",
-      "routing_key": "events.caseProcessor.updateSampleSensitive",
+      "routing_key": "events.updateSampleSensitive",
+      "arguments": {
+      }
+    },
+    {
+      "source": "events",
+      "vhost": "/",
+      "destination": "events.caseProcessor.fulfilment",
+      "destination_type": "queue",
+      "routing_key": "events.fulfilment",
       "arguments": {
       }
     },
@@ -192,7 +201,7 @@
       "vhost": "/",
       "destination": "events.caseProcessor.refusal",
       "destination_type": "queue",
-      "routing_key": "events.caseProcessor.refusal",
+      "routing_key": "events.refusal",
       "arguments": {
       }
     },
@@ -201,7 +210,7 @@
       "vhost": "/",
       "destination": "events.caseProcessor.response",
       "destination_type": "queue",
-      "routing_key": "events.caseProcessor.response",
+      "routing_key": "events.response",
       "arguments": {
       }
     },
@@ -210,7 +219,7 @@
       "vhost": "/",
       "destination": "events.rh.uacUpdate",
       "destination_type": "queue",
-      "routing_key": "events.rh.uacUpdate",
+      "routing_key": "events.uacUpdate",
       "arguments": {
       }
     },
@@ -228,7 +237,7 @@
       "vhost": "/",
       "destination": "events.rh.caseUpdate",
       "destination_type": "queue",
-      "routing_key": "events.rh.caseUpdate",
+      "routing_key": "events.caseUpdate",
       "arguments": {
       }
     },
@@ -246,7 +255,7 @@
       "vhost": "/",
       "destination": "events.caseProcessor.invalidAddress",
       "destination_type": "queue",
-      "routing_key": "events.caseProcessor.invalidAddress",
+      "routing_key": "events.invalidAddress",
       "arguments": {}
     },
     {
@@ -254,7 +263,7 @@
       "vhost": "/",
       "destination": "events.caseProcessor.surveyLaunched",
       "destination_type": "queue",
-      "routing_key": "events.caseProcessor.surveyLaunched",
+      "routing_key": "events.surveyLaunched",
       "arguments": {
       }
     },
@@ -263,7 +272,7 @@
       "vhost": "/",
       "destination": "events.caseProcessor.deactivateUac",
       "destination_type": "queue",
-      "routing_key": "events.caseProcessor.deactivateUac",
+      "routing_key": "events.deactivateUac",
       "arguments": {
       }
     },


### PR DESCRIPTION
# Motivation and Context
Routing key != queue name. If you want to send directly to a queue, use the default exchange. Otherwise, use the `events` exchange with a meaningful routing key.

# What has changed
Named the routing keys better.

# How to test?
Run the ATs. Should be zero regression.

# Links
Trello: https://trello.com/c/4CgML4w6