### PR TITLE
Fix healthchecks

### DIFF
--- a/rm-services.yml
+++ b/rm-services.yml
@@ -43,7 +43,7 @@ services:
       - SPRING_RABBITMQ_PORT=${RABBIT_PORT}
     restart: always
     healthcheck:
-      test: [ "CMD", "curl", "-f", "http://localhost:8161/actuator/info" ]
+      test: [ "CMD", "curl", "-f", "http://localhost:8161/actuator/health" ]
       interval: 60s
       timeout: 10s
       retries: 4
@@ -64,7 +64,7 @@ services:
       - SPRING_DATASOURCE_PASSWORD=${POSTGRES_PASSWORD}
     restart: always
     healthcheck:
-      test: [ "CMD", "curl", "-f", "http://localhost:8164/actuator/info" ]
+      test: [ "CMD", "curl", "-f", "http://localhost:8164/actuator/health" ]
       interval: 60s
       timeout: 10s
       retries: 4
@@ -84,7 +84,7 @@ services:
       - SPRING_RABBITMQ_HOST=${RABBIT_HOST}
       - SPRING_RABBITMQ_PORT=${RABBIT_PORT}
     healthcheck:
-      test: [ "CMD", "curl", "-f", "http://localhost:8666/actuator/info" ]
+      test: [ "CMD", "curl", "-f", "http://localhost:8666/actuator/health" ]
       interval: 60s
       timeout: 10s
       retries: 4

--- a/rm-services.yml
+++ b/rm-services.yml
@@ -144,7 +144,7 @@ services:
       - SPRING_DATASOURCE_PASSWORD=${POSTGRES_PASSWORD}
     restart: always
     healthcheck:
-      test: [ "CMD", "curl", "-f", "http://localhost:9999/actuator/info" ]
+      test: [ "CMD", "curl", "-f", "http://localhost:9999/actuator/health" ]
       interval: 60s
       timeout: 10s
       retries: 4


### PR DESCRIPTION
# Motivation and Context
Healthchecks aren't working for liveliness and readiness in K8S/GCP.

# What has changed
Fixed to use the health actuator endpoint.

# How to test?
Spin up an environment and check the services go healthy and stay healthy.

# Links
Trello: https://trello.com/c/VZi1vSpu