### PR TITLE
Make it easier to test RBAC

### DIFF
--- a/.env
+++ b/.env
@@ -72,3 +72,6 @@ EXCEPTIONMANAGER_PORT=8666
 
 # Case Ref Format Preserving Encryption
 CASEREFGENERATORKEY=lOpnY+IDq10Sts/D6kVRPFpZ+y7X+86H
+
+# Dummy user for RBAC testing
+DUMMY_USER=dummy@fake-email.com

--- a/rm-services.yml
+++ b/rm-services.yml
@@ -142,6 +142,7 @@ services:
       - SPRING_RABBITMQ_PORT=${RABBIT_PORT}
       - SPRING_DATASOURCE_USERNAME=${POSTGRES_USERNAME}
       - SPRING_DATASOURCE_PASSWORD=${POSTGRES_PASSWORD}
+      - DUMMYUSERIDENTITY=${DUMMY_USER}
     restart: always
     healthcheck:
       test: [ "CMD", "curl", "-f", "http://localhost:9999/actuator/health" ]


### PR DESCRIPTION
# Motivation and Context
Currently, when testing via Docker Dev on a local machine, the identity is faked as `dummy@fake-email.com` which is also granted super user permission, by default.

We need a mechanism to fake different user identities, so that we can test that RBAC is working.

# What has changed
Created environment variable called `DUMMY_USER` in the `.env` file in docker dev. This can be changed to fake any email you want, but you will need to ensure the user is present in the `users` table in the database and has been granted permissions via group membership etc.

# How to test?
Change the user to anything other than `dummy@fake-email.com` and then set it up in the DB with some permissions, and you should see RBAC working locally.

# Links
Trello: https://trello.com/c/oO5I3bIz