### PR TITLE
Use shared project for shared pubsub topics and subscriptions

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,4 +165,4 @@ hard and fast numbers, this is just what worked for people.
 
 ## Publishing to Pub/Sub Topics in Emulator
 
-Run `./publish_message.sh <TOPIC>` and then paste in a JSON message. Press CTRL-D when you're done.
+Run `./publish_message.sh <PROJECT> <TOPIC>` and then paste in a JSON message. Press CTRL-D when you're done.

--- a/publish_message.sh
+++ b/publish_message.sh
@@ -1,9 +1,9 @@
 #!/bin/sh
 
-if [ $# -ne 1 ]
+if [ $# -ne 2 ]
 then
-    echo "Usage: publish_message.sh <TOPIC>"
+    echo "Usage: publish_message.sh <PROJECT> <TOPIC>"
     exit -1
 fi
 
-PIPENV_DONT_LOAD_ENV=1 PUBSUB_EMULATOR_HOST=localhost:8538 pipenv run python publish_message.py $1
+PIPENV_DONT_LOAD_ENV=1 PUBSUB_EMULATOR_HOST=localhost:8538 pipenv run python publish_message.py $1 --project $2

--- a/rm-services.yml
+++ b/rm-services.yml
@@ -9,7 +9,7 @@ services:
       - pubsub-emulator
     environment:
       - SPRING_CLOUD_GCP_PUBSUB_EMULATOR_HOST=pubsub-emulator:8538
-      - SPRING_CLOUD_GCP_PUBSUB_PROJECT_ID=project
+      - SPRING_CLOUD_GCP_PUBSUB_PROJECT_ID=our-project
       - SPRING_DATASOURCE_URL=jdbc:postgresql://postgres:${POSTGRES_PORT}/${POSTGRES_HOST}?sslmode=disable
       - UACSERVICE_CONNECTION_HOST=${UAC_HOST}
       - UACSERVICE_CONNECTION_PORT=${UAC_PORT}
@@ -36,7 +36,7 @@ services:
       - pubsub-emulator
     environment:
       - SPRING_CLOUD_GCP_PUBSUB_EMULATOR_HOST=pubsub-emulator:8538
-      - SPRING_CLOUD_GCP_PUBSUB_PROJECT_ID=project
+      - SPRING_CLOUD_GCP_PUBSUB_PROJECT_ID=our-project
       - SPRING_DATASOURCE_URL=jdbc:postgresql://postgres:${POSTGRES_PORT}/${POSTGRES_HOST}?sslmode=disable
       - SPRING_DATASOURCE_USERNAME=${POSTGRES_USERNAME}
       - SPRING_DATASOURCE_PASSWORD=${POSTGRES_PASSWORD}
@@ -98,6 +98,7 @@ services:
       - sftp
     environment:
       - PUBSUB_EMULATOR_HOST=pubsub-emulator:8538
+      - PUBSUB_PROJECT=our-project
       - READINESS_FILE_PATH=/tmp/ready
       - ENVIRONMENT=DEV
       - SFTP_HOST=sftp

--- a/rm-services.yml
+++ b/rm-services.yml
@@ -9,7 +9,6 @@ services:
       - pubsub-emulator
     environment:
       - SPRING_CLOUD_GCP_PUBSUB_EMULATOR_HOST=pubsub-emulator:8538
-      - SPRING_CLOUD_GCP_PUBSUB_PROJECT_ID=our-project
       - SPRING_DATASOURCE_URL=jdbc:postgresql://postgres:${POSTGRES_PORT}/${POSTGRES_HOST}?sslmode=disable
       - UACSERVICE_CONNECTION_HOST=${UAC_HOST}
       - UACSERVICE_CONNECTION_PORT=${UAC_PORT}
@@ -132,7 +131,6 @@ services:
       - postgres
     environment:
       - SPRING_CLOUD_GCP_PUBSUB_EMULATOR_HOST=pubsub-emulator:8538
-      - SPRING_CLOUD_GCP_PUBSUB_PROJECT_ID=project
       - SPRING_DATASOURCE_URL=jdbc:postgresql://postgres:${POSTGRES_PORT}/${POSTGRES_HOST}?sslmode=disable
       - SPRING_DATASOURCE_USERNAME=${POSTGRES_USERNAME}
       - SPRING_DATASOURCE_PASSWORD=${POSTGRES_PASSWORD}

--- a/setup_pubsub.sh
+++ b/setup_pubsub.sh
@@ -5,42 +5,42 @@ source .env
 # Wait for pubsub-emulator to come up
 bash -c 'while [[ "$(curl -s -o /dev/null -w ''%{http_code}'' '$PUBSUB_SETUP_HOST')" != "200" ]]; do sleep 1; done'
 
-curl -X PUT http://$PUBSUB_SETUP_HOST/v1/projects/project/topics/rm-internal-telephone-capture
-curl -X PUT http://$PUBSUB_SETUP_HOST/v1/projects/project/subscriptions/rm-internal-telephone-capture_case-processor -H 'Content-Type: application/json' -d '{"topic": "projects/project/topics/rm-internal-telephone-capture"}'
+curl -X PUT http://$PUBSUB_SETUP_HOST/v1/projects/our-project/topics/rm-internal-telephone-capture
+curl -X PUT http://$PUBSUB_SETUP_HOST/v1/projects/our-project/subscriptions/rm-internal-telephone-capture_case-processor -H 'Content-Type: application/json' -d '{"topic": "projects/our-project/topics/rm-internal-telephone-capture"}'
 
-curl -X PUT http://$PUBSUB_SETUP_HOST/v1/projects/project/topics/rm-internal-sample
-curl -X PUT http://$PUBSUB_SETUP_HOST/v1/projects/project/subscriptions/rm-internal-sample_case-processor -H 'Content-Type: application/json' -d '{"topic": "projects/project/topics/rm-internal-sample"}'
+curl -X PUT http://$PUBSUB_SETUP_HOST/v1/projects/our-project/topics/rm-internal-sample
+curl -X PUT http://$PUBSUB_SETUP_HOST/v1/projects/our-project/subscriptions/rm-internal-sample_case-processor -H 'Content-Type: application/json' -d '{"topic": "projects/our-project/topics/rm-internal-sample"}'
 
-curl -X PUT http://$PUBSUB_SETUP_HOST/v1/projects/project/topics/event_receipt
-curl -X PUT http://$PUBSUB_SETUP_HOST/v1/projects/project/subscriptions/event_receipt_rm-case-processor -H 'Content-Type: application/json' -d '{"topic": "projects/project/topics/event_receipt"}'
+curl -X PUT http://$PUBSUB_SETUP_HOST/v1/projects/our-project/topics/rm-internal-print-row
+curl -X PUT http://$PUBSUB_SETUP_HOST/v1/projects/our-project/subscriptions/rm-internal-print-row_print-file-service -H 'Content-Type: application/json' -d '{"topic": "projects/our-project/topics/rm-internal-print-row"}'
 
-curl -X PUT http://$PUBSUB_SETUP_HOST/v1/projects/project/topics/event_refusal
-curl -X PUT http://$PUBSUB_SETUP_HOST/v1/projects/project/subscriptions/event_refusal_rm-case-processor -H 'Content-Type: application/json' -d '{"topic": "projects/project/topics/event_refusal"}'
+curl -X PUT http://$PUBSUB_SETUP_HOST/v1/projects/shared-project/topics/event_receipt
+curl -X PUT http://$PUBSUB_SETUP_HOST/v1/projects/shared-project/subscriptions/event_receipt_rm-case-processor -H 'Content-Type: application/json' -d '{"topic": "projects/shared-project/topics/event_receipt"}'
 
-curl -X PUT http://$PUBSUB_SETUP_HOST/v1/projects/project/topics/rm-internal-print-row
-curl -X PUT http://$PUBSUB_SETUP_HOST/v1/projects/project/subscriptions/rm-internal-print-row_print-file-service -H 'Content-Type: application/json' -d '{"topic": "projects/project/topics/rm-internal-print-row"}'
+curl -X PUT http://$PUBSUB_SETUP_HOST/v1/projects/shared-project/topics/event_refusal
+curl -X PUT http://$PUBSUB_SETUP_HOST/v1/projects/shared-project/subscriptions/event_refusal_rm-case-processor -H 'Content-Type: application/json' -d '{"topic": "projects/shared-project/topics/event_refusal"}'
 
-curl -X PUT http://$PUBSUB_SETUP_HOST/v1/projects/project/topics/event_invalid-case
-curl -X PUT http://$PUBSUB_SETUP_HOST/v1/projects/project/subscriptions/event_invalid-case_rm-case-processor -H 'Content-Type: application/json' -d '{"topic": "projects/project/topics/event_invalid-case"}'
+curl -X PUT http://$PUBSUB_SETUP_HOST/v1/projects/shared-project/topics/event_invalid-case
+curl -X PUT http://$PUBSUB_SETUP_HOST/v1/projects/shared-project/subscriptions/event_invalid-case_rm-case-processor -H 'Content-Type: application/json' -d '{"topic": "projects/shared-project/topics/event_invalid-case"}'
 
-curl -X PUT http://$PUBSUB_SETUP_HOST/v1/projects/project/topics/event_survey-launch
-curl -X PUT http://$PUBSUB_SETUP_HOST/v1/projects/project/subscriptions/event_survey-launch_rm-case-processor -H 'Content-Type: application/json' -d '{"topic": "projects/project/topics/event_survey-launch"}'
+curl -X PUT http://$PUBSUB_SETUP_HOST/v1/projects/shared-project/topics/event_survey-launch
+curl -X PUT http://$PUBSUB_SETUP_HOST/v1/projects/shared-project/subscriptions/event_survey-launch_rm-case-processor -H 'Content-Type: application/json' -d '{"topic": "projects/shared-project/topics/event_survey-launch"}'
 
-curl -X PUT http://$PUBSUB_SETUP_HOST/v1/projects/project/topics/event_uac-authentication
-curl -X PUT http://$PUBSUB_SETUP_HOST/v1/projects/project/subscriptions/event_uac-authentication_rm-case-processor -H 'Content-Type: application/json' -d '{"topic": "projects/project/topics/event_uac-authentication"}'
+curl -X PUT http://$PUBSUB_SETUP_HOST/v1/projects/shared-project/topics/event_uac-authentication
+curl -X PUT http://$PUBSUB_SETUP_HOST/v1/projects/shared-project/subscriptions/event_uac-authentication_rm-case-processor -H 'Content-Type: application/json' -d '{"topic": "projects/shared-project/topics/event_uac-authentication"}'
 
-curl -X PUT http://$PUBSUB_SETUP_HOST/v1/projects/project/topics/event_print-fulfilment
-curl -X PUT http://$PUBSUB_SETUP_HOST/v1/projects/project/subscriptions/event_print-fulfilment_rm-case-processor -H 'Content-Type: application/json' -d '{"topic": "projects/project/topics/event_print-fulfilment"}'
+curl -X PUT http://$PUBSUB_SETUP_HOST/v1/projects/shared-project/topics/event_print-fulfilment
+curl -X PUT http://$PUBSUB_SETUP_HOST/v1/projects/shared-project/subscriptions/event_print-fulfilment_rm-case-processor -H 'Content-Type: application/json' -d '{"topic": "projects/shared-project/topics/event_print-fulfilment"}'
 
-curl -X PUT http://$PUBSUB_SETUP_HOST/v1/projects/project/topics/event_deactivate-uac
-curl -X PUT http://$PUBSUB_SETUP_HOST/v1/projects/project/subscriptions/event_deactivate-uac_rm-case-processor -H 'Content-Type: application/json' -d '{"topic": "projects/project/topics/event_deactivate-uac"}'
+curl -X PUT http://$PUBSUB_SETUP_HOST/v1/projects/shared-project/topics/event_deactivate-uac
+curl -X PUT http://$PUBSUB_SETUP_HOST/v1/projects/shared-project/subscriptions/event_deactivate-uac_rm-case-processor -H 'Content-Type: application/json' -d '{"topic": "projects/shared-project/topics/event_deactivate-uac"}'
 
-curl -X PUT http://$PUBSUB_SETUP_HOST/v1/projects/project/topics/event_update-sample-sensitive
-curl -X PUT http://$PUBSUB_SETUP_HOST/v1/projects/project/subscriptions/event_update-sample-sensitive_rm-case-processor -H 'Content-Type: application/json' -d '{"topic": "projects/project/topics/event_update-sample-sensitive"}'
+curl -X PUT http://$PUBSUB_SETUP_HOST/v1/projects/shared-project/topics/event_update-sample-sensitive
+curl -X PUT http://$PUBSUB_SETUP_HOST/v1/projects/shared-project/subscriptions/event_update-sample-sensitive_rm-case-processor -H 'Content-Type: application/json' -d '{"topic": "projects/shared-project/topics/event_update-sample-sensitive"}'
 
-curl -X PUT http://$PUBSUB_SETUP_HOST/v1/projects/project/topics/event_case-update
-curl -X PUT http://$PUBSUB_SETUP_HOST/v1/projects/project/subscriptions/event_case-update_rh -H 'Content-Type: application/json' -d '{"topic": "projects/project/topics/event_case-update"}'
+curl -X PUT http://$PUBSUB_SETUP_HOST/v1/projects/shared-project/topics/event_case-update
+curl -X PUT http://$PUBSUB_SETUP_HOST/v1/projects/shared-project/subscriptions/event_case-update_rh -H 'Content-Type: application/json' -d '{"topic": "projects/shared-project/topics/event_case-update"}'
 
-curl -X PUT http://$PUBSUB_SETUP_HOST/v1/projects/project/topics/event_uac-update
-curl -X PUT http://$PUBSUB_SETUP_HOST/v1/projects/project/subscriptions/event_uac-update_rh -H 'Content-Type: application/json' -d '{"topic": "projects/project/topics/event_uac-update"}'
+curl -X PUT http://$PUBSUB_SETUP_HOST/v1/projects/shared-project/topics/event_uac-update
+curl -X PUT http://$PUBSUB_SETUP_HOST/v1/projects/shared-project/subscriptions/event_uac-update_rh -H 'Content-Type: application/json' -d '{"topic": "projects/shared-project/topics/event_uac-update"}'
 


### PR DESCRIPTION
# Motivation and Context
RM doesn't 'own' the topics and subscriptions which are used to integrate between other products... and as such, they should be kept in a shared project.

# What has changed
Use our own project only for internal messaging, otherwise use a shared project.

# How to test?
Build Case Processor and Support Tool, then start everything up in docker dev with `make up` and then run the acceptance tests with `make test`... should be zero regression.

# Links
Trello: https://trello.com/c/yPZ72ten