### PR TITLE
Sort out pubsub config once and for all

### DIFF
--- a/rm-services.yml
+++ b/rm-services.yml
@@ -8,6 +8,7 @@ services:
       - uacqid
       - pubsub-emulator
     environment:
+      - spring_profiles_active=emulator
       - SPRING_CLOUD_GCP_PUBSUB_EMULATOR_HOST=pubsub-emulator:8538
       - SPRING_DATASOURCE_URL=jdbc:postgresql://postgres:${POSTGRES_PORT}/${POSTGRES_HOST}?sslmode=disable
       - UACSERVICE_CONNECTION_HOST=${UAC_HOST}
@@ -130,6 +131,7 @@ services:
       - pubsub-emulator
       - postgres
     environment:
+      - spring_profiles_active=emulator
       - SPRING_CLOUD_GCP_PUBSUB_EMULATOR_HOST=pubsub-emulator:8538
       - SPRING_DATASOURCE_URL=jdbc:postgresql://postgres:${POSTGRES_PORT}/${POSTGRES_HOST}?sslmode=disable
       - SPRING_DATASOURCE_USERNAME=${POSTGRES_USERNAME}


### PR DESCRIPTION
# Motivation and Context
Configuring pubsub for both emulator (i.e. for integration testing, acceptance tests and generally running locally) and "prod" in GCP is not trivial.

# What has changed
Split out a "test" profile from an "emulator" profile, and made the "prod" config  disable its normal config if test/emulator profile is active.

# How to test?
Run the ATs... zero regression. AND run in GCP... should work fine.

# Links
Trello: https://trello.com/c/yPZ72ten