### PR TITLE
Use fully qualified Pub/Sub topic and subscription names

### DIFF
--- a/rm-services.yml
+++ b/rm-services.yml
@@ -138,7 +138,6 @@ services:
       - SPRING_DATASOURCE_URL=jdbc:postgresql://postgres:${POSTGRES_PORT}/${POSTGRES_HOST}?sslmode=disable
       - SPRING_DATASOURCE_USERNAME=${POSTGRES_USERNAME}
       - SPRING_DATASOURCE_PASSWORD=${POSTGRES_PASSWORD}
-      - SPRING_CLOUD_GCP_PUBSUB-EMULATOR-HOST=pubsub-emulator:8538
       - DUMMYUSERIDENTITY=${DUMMY_USER}
     restart: always
     healthcheck:

--- a/rm-services.yml
+++ b/rm-services.yml
@@ -8,8 +8,9 @@ services:
       - uacqid
       - pubsub-emulator
     environment:
-      - spring_profiles_active=emulator
       - SPRING_CLOUD_GCP_PUBSUB_EMULATOR_HOST=pubsub-emulator:8538
+      - SPRING_CLOUD_GCP_PUBSUB_PROJECT-ID=our-project
+      - QUEUECONFIG_SHARED-PUBSUB-PROJECT=shared-project
       - SPRING_DATASOURCE_URL=jdbc:postgresql://postgres:${POSTGRES_PORT}/${POSTGRES_HOST}?sslmode=disable
       - UACSERVICE_CONNECTION_HOST=${UAC_HOST}
       - UACSERVICE_CONNECTION_PORT=${UAC_PORT}
@@ -131,8 +132,9 @@ services:
       - pubsub-emulator
       - postgres
     environment:
-      - spring_profiles_active=emulator
       - SPRING_CLOUD_GCP_PUBSUB_EMULATOR_HOST=pubsub-emulator:8538
+      - SPRING_CLOUD_GCP_PUBSUB_PROJECT-ID=our-project
+      - QUEUECONFIG_SHARED-PUBSUB-PROJECT=shared-project
       - SPRING_DATASOURCE_URL=jdbc:postgresql://postgres:${POSTGRES_PORT}/${POSTGRES_HOST}?sslmode=disable
       - SPRING_DATASOURCE_USERNAME=${POSTGRES_USERNAME}
       - SPRING_DATASOURCE_PASSWORD=${POSTGRES_PASSWORD}


### PR DESCRIPTION
# Motivation and Context
Having completely separate config for the PubSubTemplate for our project, shared project and emulator too, created a lot of config code to have to manage. It turns out that it was nearly all redundant: we just needed to use fully qualified topic and subscription names, to specify specific projects.

# What has changed
Refactored to use fully qualified names of topics and subscriptions, where they exist outside our project.

# How to test?
Zero regression in any of the tests. Can connect to your GCP project too, if you fiddle with the config to point at your GCP project (see README).

# Links
Trello: https://trello.com/c/Wp6A6wc2