### PR TITLE
Configure print suppliers via JSON file

### DIFF
--- a/rm-services.yml
+++ b/rm-services.yml
@@ -162,6 +162,7 @@ services:
       - SPRING_DATASOURCE_USERNAME=${POSTGRES_USERNAME}
       - SPRING_DATASOURCE_PASSWORD=${POSTGRES_PASSWORD}
       - DUMMYUSERIDENTITY=${DUMMY_USER}
+      - PRINTSUPPLIERCONFIGFILE=/home/response-operations/dummy_supplier_config.json
     restart: always
     healthcheck:
       test: [ "CMD", "curl", "-f", "http://localhost:7777/actuator/health" ]
@@ -169,6 +170,8 @@ services:
       timeout: 10s
       retries: 4
       start_period: 50s
+    volumes:
+      - ./dummy_supplier_config.json:/home/response-operations/dummy_supplier_config.json
 
   notifyservice:
     container_name: notifyservice

--- a/rm-services.yml
+++ b/rm-services.yml
@@ -139,6 +139,7 @@ services:
       - SPRING_DATASOURCE_USERNAME=${POSTGRES_USERNAME}
       - SPRING_DATASOURCE_PASSWORD=${POSTGRES_PASSWORD}
       - DUMMYUSERIDENTITY=${DUMMY_USER}
+      - PRINTSUPPLIERCONFIGFILE=/home/supporttool/dummy_supplier_config.json
     restart: always
     healthcheck:
       test: [ "CMD", "curl", "-f", "http://localhost:9999/actuator/health" ]
@@ -146,7 +147,8 @@ services:
       timeout: 10s
       retries: 4
       start_period: 50s
-
+    volumes:
+      - ./dummy_supplier_config.json:/home/supporttool/dummy_supplier_config.json
 
   rops:
     container_name: rops


### PR DESCRIPTION
# Motivation and Context
The list of print suppliers should be globally configured via the K8S configmap file, which is JSON format.

# What has changed
Ripped out the hacked JSON config held in `application.yml` and replaced with file-based config, mounted by Docker/K8S.

# How to test?
Zero regression.

# Links
Trello: https://trello.com/c/W9SX2a5n