### PR TITLE
Remove sftp from export file service

### DIFF
--- a/.env
+++ b/.env
@@ -8,11 +8,6 @@ POSTGRES_PORT=5432
 POSTGRES_DATABASE=postgres
 EX_POSTGRES_PORT=6432
 
-# SFTP
-SFTP_HOST=sftp
-SFTP_PORT=22
-EX_SFTP_PORT=122
-
 # UAC
 UAC_HOST=uacqid
 UAC_PORT=8164
@@ -52,3 +47,7 @@ DUMMY_USER=dummy@fake-email.com
 
 # Response Operations UI/API
 ROPS_PORT=7777
+
+# Export file service
+PLATFORM=LOCAL
+EXPORT_FILE_LOCATION=/export_files

--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ make up
 ## Slowstart
 
 There are 2 docker-compose files in this repository:
-- dev.yml - spins up the core development containers such as postgres, rabbit and sftp
+- dev.yml - spins up the core development containers such as postgres
 - rm-services.yml - spins up the Java and Go services such as survey service and action service
 
 These can be run together as per the Quickstart section or individually.  Additionally individual services can be specified at the end of the command. For example:

--- a/dev.yml
+++ b/dev.yml
@@ -7,17 +7,6 @@ services:
     ports:
       - "${EX_POSTGRES_PORT}:5432"
 
-  sftp:
-    container_name: sftp
-    image: atmoz/sftp
-    volumes:
-      - ~/Documents/sftp/supplier_A/print_services/:/home/centos/supplier_A/print_services/
-      - ~/Documents/sftp/supplier_B/print_services/:/home/centos/supplier_B/print_services/
-      - ./dummy_keys/dummy_rsa.pub:/home/centos/.ssh/keys/dummy_rsa.pub:ro
-    ports:
-      - "${EX_SFTP_PORT}:22"
-    command: centos::2000
-
   pgadmin:
     container_name: pgadmin
     image: dpage/pgadmin4

--- a/dummy_destination_config.json
+++ b/dummy_destination_config.json
@@ -1,10 +1,10 @@
 {
   "SUPPLIER_A": {
-    "sftpDirectory": "supplier_A/print_services/",
+    "exportDirectory": "supplier_A/print_services/",
     "encryptionKeyFilename": "dummy-key-supplier-a-public.asc"
   },
   "SUPPLIER_B": {
-    "sftpDirectory": "supplier_B/print_services/",
+    "exportDirectory": "supplier_B/print_services/",
     "encryptionKeyFilename": "dummy-key-supplier-b-public.asc"
   }
 }

--- a/rm-services.yml
+++ b/rm-services.yml
@@ -96,15 +96,9 @@ services:
     image: eu.gcr.io/ssdc-rm-ci/rm/ssdc-rm-export-file-service
     external_links:
       - pubsub-emulator
-      - sftp
     environment:
       - READINESS_FILE_PATH=/tmp/ready
       - ENVIRONMENT=DEV
-      - SFTP_HOST=sftp
-      - SFTP_PORT=22
-      - SFTP_USERNAME=centos
-      - SFTP_KEY_FILENAME=/home/export-file-service/dummy_keys/dummy_rsa
-      - SFTP_PASSPHRASE=dummy_secret
       - EXCEPTIONMANAGER_CONNECTION_HOST=${EXCEPTIONMANAGER_HOST}
       - EXCEPTIONMANAGER_CONNECTION_PORT=${EXCEPTIONMANAGER_PORT}
       - DESTINATION_CONFIG_JSON_PATH=/home/export-file-service/dummy_destination_config.json
@@ -114,6 +108,8 @@ services:
       - DB_USERNAME=${POSTGRES_USERNAME}
       - DB_PASSWORD=${POSTGRES_PASSWORD}
       - DB_DATABASE=${POSTGRES_DATABASE}
+      - SENT_EXPORT_FILE_BUCKET=./export_files
+      - PLATFORM=LOCAL
     restart: always
     healthcheck:
       test: sh -c "[ -f /tmp/ready ]"
@@ -124,7 +120,7 @@ services:
     volumes:
       - ./dummy_keys:/home/export-file-service/dummy_keys
       - ./dummy_destination_config.json:/home/export-file-service/dummy_destination_config.json
-
+      - /tmp:/home/export-file-service/export_files
 
   supporttool:
     container_name: supporttool

--- a/rm-services.yml
+++ b/rm-services.yml
@@ -108,8 +108,9 @@ services:
       - DB_USERNAME=${POSTGRES_USERNAME}
       - DB_PASSWORD=${POSTGRES_PASSWORD}
       - DB_DATABASE=${POSTGRES_DATABASE}
-      - SENT_EXPORT_FILE_BUCKET=./export_files
-      - PLATFORM=LOCAL
+      - FILE_UPLOAD_DESTINATION=/home/export-file-service/export_files
+      - FILE_UPLOAD_MODE=LOCAL
+
     restart: always
     healthcheck:
       test: sh -c "[ -f /tmp/ready ]"
@@ -120,7 +121,7 @@ services:
     volumes:
       - ./dummy_keys:/home/export-file-service/dummy_keys
       - ./dummy_destination_config.json:/home/export-file-service/dummy_destination_config.json
-      - /tmp:/home/export-file-service/export_files
+      - ~/Documents/export_files:/home/export-file-service/export_files
 
   supporttool:
     container_name: supporttool


### PR DESCRIPTION
# Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
We no longer want to use sftp as the place to put export files, instead for now we only want to use GCS buckets

# What has changed
<!--- What code changes has been made -->
<!--- Has there been any refactoring -->
<!--- What tests have been written -->
Everything sftp removed, variables added to export file service to configure running locally or using GCS buckets

# How to test?
<!--- Describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc. -->
<!--- Are there any automated tests that mean changes don't need to be manually changed -->
Running locally
1. Follow instructions to build export file service on its PR
3. with `ssdc-rm-docker-dev` on branch of the same name: `make up`
4. with `ssdc-rm-acceptance-tests` on branch of the same name: `make test`

Running locally using real GCS buckets:
1. Follow the new instructions on the export file service to set variables
2. Do the same in the acceptance tests
3. `make test`

# Links
<!--- Add any links to issues (trello, github issues) -->
<!--- Links to any documentation -->
<!--- Links to any related PRs -->
https://trello.com/c/tqkddH1D/3019-export-file-service-remove-sftp-just-send-files-to-a-gcs-bucket-or-local-directory-8
# Screenshots (if appropriate):