### PR TITLE
Migrate scheduled parts of Support Tool into Job Processor

### DIFF
--- a/checkout_and_build_pr.sh
+++ b/checkout_and_build_pr.sh
@@ -191,6 +191,9 @@ checkout_and_build_repo_branch "ssdc-rm-uac-qid-service" $BRANCH_NAME "${MVN_INS
 #Exception Manger
 checkout_and_build_repo_branch "ssdc-rm-exception-manager" $BRANCH_NAME "${MVN_INSTALL_TEST_CMD}" "${MVN_INSTALL_ONLY_CMD}"
 
+# Job Processor
+checkout_and_build_repo_branch "ssdc-rm-job-processor" $BRANCH_NAME "make build" "make build_no_test"
+
 ########################################################################################################################
 #  Set up Docker Dev
 ########################################################################################################################

--- a/rm-services.yml
+++ b/rm-services.yml
@@ -209,6 +209,27 @@ services:
       retries: 4
       start_period: 50s
 
+  jobprocessor:
+    container_name: jobprocessor
+    image: eu.gcr.io/ssdc-rm-ci/rm/ssdc-rm-job-processor
+    external_links:
+      - pubsub-emulator
+      - postgres
+    environment:
+      - SPRING_CLOUD_GCP_PUBSUB_EMULATOR_HOST=pubsub-emulator:8538
+      - SPRING_CLOUD_GCP_PUBSUB_PROJECT-ID=our-project
+      - QUEUECONFIG_SHARED-PUBSUB-PROJECT=shared-project
+      - SPRING_DATASOURCE_URL=jdbc:postgresql://postgres:${POSTGRES_PORT}/${POSTGRES_HOST}?sslmode=disable
+      - SPRING_DATASOURCE_USERNAME=${POSTGRES_USERNAME}
+      - SPRING_DATASOURCE_PASSWORD=${POSTGRES_PASSWORD}
+    restart: always
+    healthcheck:
+      test: [ "CMD", "find", "/tmp/job-processor-healthy", "-mmin", "-1" ]
+      interval: 60s
+      timeout: 10s
+      retries: 10
+      start_period: 45s
+
 networks:
   default:
     external:


### PR DESCRIPTION
# Motivation and Context
Currently, we can not have more than one instance of the Support Tool running, meaning that we are not able to do rolling upgrades, so there are outages when we deploy new versions. Also, the Support Tool API can be adversely affected by the workload of sample load and validation, which can affect UI responsiveness.

# What has changed
Migrated the scheduled parts of Support Tool into the Job Processor.

# How to test?
Zero regression - ATs should continue to pass as normal.

# Links
Trello: https://trello.com/c/nOrXHmfn