### PR TITLE
3196 - Enable dummy user handling

### DIFF
--- a/rm-services.yml
+++ b/rm-services.yml
@@ -171,6 +171,7 @@ services:
       - SPRING_DATASOURCE_USERNAME=${POSTGRES_USERNAME}
       - SPRING_DATASOURCE_PASSWORD=${POSTGRES_PASSWORD}
       - DUMMYUSERIDENTITY=${DUMMY_USER}
+      - DUMMYUSERIDENTITY-ALLOWED=true
       - EXPORTFILEDESTINATIONCONFIGFILE=/home/response-operations/dummy_destination_config.json
     restart: always
     healthcheck:


### PR DESCRIPTION
# Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
We should make use of the same safeguards in the Support Tool which prevent the dummy user account from being used maliciously in production.

# What has changed
<!--- What code changes has been made -->
<!--- Has there been any refactoring -->
<!--- What tests have been written -->
Made use of Support Tool safeguards

# How to test?
<!--- Describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc. -->
<!--- Are there any automated tests that mean changes don't need to be manually changed -->
See 'How to test' from [this PR](https://github.com/ONSdigital/ssdc-rm-support-tool/pull/129), and change support tool to response-operations

# Links
<!--- Add any links to issues (trello, github issues) -->
<!--- Links to any documentation -->
<!--- Links to any related PRs -->
https://trello.com/c/e4BUguca/3196-rops-should-have-production-quality-dummy-user-handling-the-same-as-support-tool-5