### PR TITLE
Migrate from docker-compse to docker compose

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,18 +2,18 @@ DOT := $(shell command -v dot 2> /dev/null)
 
 up:
 	docker network inspect ssdcrmdockerdev_default >/dev/null || docker network create ssdcrmdockerdev_default
-	docker-compose -f dev.yml -f rm-services.yml up -d ${SERVICE} ;
+	docker compose -f dev.yml -f rm-services.yml up -d ${SERVICE} ;
 	pipenv install --dev
 	./setup_pubsub.sh
 	
 down:
-	docker-compose -f dev.yml -f rm-services.yml down
+	docker compose -f dev.yml -f rm-services.yml down
 
 pull:
-	docker-compose -f dev.yml -f rm-services.yml pull ${SERVICE}
+	docker compose -f dev.yml -f rm-services.yml pull ${SERVICE}
 
 logs:
-	docker-compose -f dev.yml -f rm-services.yml logs --follow ${SERVICE}
+	docker compose -f dev.yml -f rm-services.yml logs --follow ${SERVICE}
 
 clean:
 	rm -f plantuml.jar; rm -f diagrams/*.svg


### PR DESCRIPTION
# Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
`docker-compose` can be replaced by `docker compose`. We want to see if this makes a difference to our repos.
# What has changed
<!--- What code changes has been made -->
<!--- Has there been any refactoring -->
<!--- What tests have been written -->
`docker-compose` replaced with `docker compose` in the makefile
# How to test?
<!--- Describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc. -->
<!--- Are there any automated tests that mean changes don't need to be manually changed -->
Check this PR out and run the various make commands to check they work as before. Run ATs.
# Links
<!--- Add any links to issues (trello, github issues) -->
<!--- Links to any documentation -->
<!--- Links to any related PRs -->
https://trello.com/c/ZQUPl3dt/3280-spike-migrate-from-docker-compose-to-docker-compose-1
# Screenshots (if appropriate):