### PR TITLE
Add basic health checks to RH services

### DIFF
--- a/rh-services.yml
+++ b/rh-services.yml
@@ -17,6 +17,12 @@ services:
       - type: bind
         source: ./fake-service-account.json
         target: /gcp/config/google-credentials.json
+    healthcheck:
+      test: [ "CMD", "curl", "-f", "http://localhost:8071/info" ]
+      interval: 5s
+      timeout: 3s
+      retries: 20
+      start_period: 5s
 
   rh-ui:
     container_name: rh-ui
@@ -33,6 +39,12 @@ services:
       - RHSVC_URL=http://host.docker.internal:8071
     ports:
       - "${RH_UI_PORT}:9092"
+    healthcheck:
+      test: [ "CMD", "curl", "-f", "http://localhost:9092/info" ]
+      interval: 5s
+      timeout: 3s
+      retries: 20
+      start_period: 5s
 
 networks:
   default:


### PR DESCRIPTION
# Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Basic health checks for the RH services, makes it easier to see status is `docker ps` for example.

# What has changed
<!--- What code changes has been made -->
<!--- Has there been any refactoring -->
<!--- What tests have been written -->
- Add healthchecks to RH services

# How to test?
<!--- Describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc. -->
<!--- Are there any automated tests that mean changes don't need to be manually changed -->
Run `make rh-up`, then `docker ps`, you should see health reported for RH service and UI indicating when they start responding on their `/info` endpoints

# Links
<!--- Add any links to issues (trello, github issues) -->
<!--- Links to any documentation -->
https://trello.com/c/WShO2yl3/3423-docker-dev-add-rh-healthchecks