### PR TITLE
Fix RH UI healthcheck

### DIFF
--- a/rh-services.yml
+++ b/rh-services.yml
@@ -40,7 +40,7 @@ services:
     ports:
       - "${RH_UI_PORT}:9092"
     healthcheck:
-      test: [ "CMD", "curl", "-f", "http://localhost:9092/info" ]
+      test: [ "CMD", "python", "-c", "import urllib.request as r; r.urlopen('http://localhost:9092/info')" ]
       interval: 5s
       timeout: 3s
       retries: 20


### PR DESCRIPTION
# Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Moving to a slim image broke the RH UI healthcheck as it does not include `curl`, do the healthcheck with python instead.

# What has changed
<!--- What code changes has been made -->
<!--- Has there been any refactoring -->
<!--- What tests have been written -->
- Do the RH UI healthcheck request with python

# How to test?
<!--- Describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc. -->
<!--- Are there any automated tests that mean changes don't need to be manually changed -->
Run `make rh-up`, then check after everything has started, check `docker ps` the `STATUS` of the `rh-ui` container should go from `starting` to `healthy`.

# Links
<!--- Add any links to issues (trello, github issues) -->
<!--- Links to any documentation -->
<!--- Links to any related PRs -->
https://trello.com/c/y6xA2Djt/57-rh-ui-tidy-up-8