### PR TITLE
155 Add new RH service

### DIFF
--- a/rh-dependencies.yml
+++ b/rh-dependencies.yml
@@ -6,12 +6,6 @@ services:
     ports:
       - "6379:6379"
 
-  firestore-emulator:
-    container_name: firestore-emulator
-    image: europe-west2-docker.pkg.dev/ssdc-rm-ci/docker/gcloud-firestore-emulator:latest
-    ports:
-      - "8542:8540"
-
   mock-service:
     container_name: mock-service
     image: europe-west2-docker.pkg.dev/ons-ci-int/int-docker-release/mock-service:latest

--- a/rh-services.yml
+++ b/rh-services.yml
@@ -1,29 +1,5 @@
 version: "3.4"
 services:
-  rh-service:
-    container_name: rh-service
-    image: europe-west2-docker.pkg.dev/ons-ci-int/int-docker-release/rh-service:latest
-    ports:
-    - "${RH_SERVICE_PORT}:8071"
-    environment:
-    - GOOGLE_APPLICATION_CREDENTIALS=/gcp/config/google-credentials.json
-    - GOOGLE_CLOUD_PROJECT=dummy-local
-    - spring.profiles.active=dev
-    - spring.cloud.gcp.pubsub.emulator-host=pubsub-emulator:8538
-    - rate-limiter.rest-client-config.host=host.docker.internal
-    - spring.cloud.gcp.pubsub.project-id=shared-project
-    - FIRESTORE_EMULATOR_HOST=firestore-emulator:8540
-    volumes:
-      - type: bind
-        source: ./fake-service-account.json
-        target: /gcp/config/google-credentials.json
-    healthcheck:
-      test: [ "CMD", "curl", "-f", "http://localhost:8071/info" ]
-      interval: 5s
-      timeout: 3s
-      retries: 20
-      start_period: 5s
-
   rh-ui:
     container_name: rh-ui
     image: europe-west2-docker.pkg.dev/ssdc-rm-ci/docker/rh-ui

--- a/rm-dependencies.yml
+++ b/rm-dependencies.yml
@@ -3,7 +3,7 @@ services:
   ons-postgres:
     container_name: postgres
     image: europe-west2-docker.pkg.dev/ssdc-rm-ci/docker/ssdc-rm-dev-common-postgres:latest
-    command: ["-c", "shared_buffers=256MB", "-c", "max_connections=500"]
+    command: [ "-c", "shared_buffers=256MB", "-c", "max_connections=500" ]
     ports:
       - "${EX_POSTGRES_PORT}:5432"
 
@@ -23,6 +23,12 @@ services:
     image: europe-west2-docker.pkg.dev/ssdc-rm-ci/docker/ssdc-rm-notify-stub:latest
     ports:
       - "8917:5000"
+
+  firestore-emulator:
+    container_name: firestore-emulator
+    image: europe-west2-docker.pkg.dev/ssdc-rm-ci/docker/gcloud-firestore-emulator:latest
+    ports:
+      - "8542:8540"
 
 networks:
   ssdcrmdockerdev_default:

--- a/rm-services.yml
+++ b/rm-services.yml
@@ -231,6 +231,23 @@ services:
       retries: 10
       start_period: 45s
 
+  rh-service:
+    container_name: rh-service
+    image: europe-west2-docker.pkg.dev/ssdc-rm-ci/docker/ssdc-rh-service:latest
+    ports:
+      - "${RH_SERVICE_PORT}:8071"
+    environment:
+      - spring.profiles.active=dev
+      - spring.cloud.gcp.pubsub.emulator-host=pubsub-emulator:8538
+      - spring.cloud.gcp.pubsub.project-id=shared-project
+      - FIRESTORE_EMULATOR_HOST=firestore-emulator:8540
+    healthcheck:
+      test: [ "CMD", "curl", "-f", "http://localhost:8071/info" ]
+      interval: 5s
+      timeout: 3s
+      retries: 20
+      start_period: 5s
+
 networks:
   default:
     external: true


### PR DESCRIPTION
# WIP

# Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
We're creating a new version of the RH service which lives with RM. This will live in our normal stack and we will in future be dropping the RH/RM services split entirely.

# What has changed
<!--- What code changes has been made -->
<!--- Has there been any refactoring -->
<!--- What tests have been written -->
- Move RH service into RM services section
- Update image URI and config
- Move Firestore emulator into RM dependencies

# How to test?
<!--- Describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc. -->
<!--- Are there any automated tests that mean changes don't need to be manually changed -->
- Spin up the RM services with `make rm-up`
- The rh-service container should start successfully
- Run the acceptance tests, manually check that cases and UACs are being written to the Firestore emulator.

# Links
<!--- Add any links to issues (trello, github issues) -->
<!--- Links to any documentation -->
<!--- Links to any related PRs -->
https://trello.com/c/SlVxleuI/155-rh-backend-remove-address-confirmation-page-and-dependency-on-address-event-handler-13