### PR TITLE
Use Java Based API Health Checks

### DIFF
--- a/java_healthcheck/HealthCheck.java
+++ b/java_healthcheck/HealthCheck.java
@@ -1,0 +1,16 @@
+import java.net.*;
+
+public class HealthcheckRequest {
+  public static void main(String[] args) throws Exception {
+    if (args.length != 1) {
+      throw new IllegalArgumentException("Expected exactly one argument, the URL to GET");
+    }
+    URL url = new URL(args[0]);
+    HttpURLConnection con = (HttpURLConnection) url.openConnection();
+    con.setRequestMethod("GET");
+    int status = con.getResponseCode();
+    if (status != 200) {
+      System.exit(1);
+    }
+  }
+}

--- a/java_healthcheck/HealthCheck.java
+++ b/java_healthcheck/HealthCheck.java
@@ -1,14 +1,23 @@
 import java.net.*;
 
-public class HealthcheckRequest {
+public class HealthCheck {
+  // A simple Java class for testing a GET endpoint responds with status code 200 inside Java containers
+  // Usage: java <PATH_TO_THIS_CLASS>/HealthCheck.java <HEALTH_URL>
+
   public static void main(String[] args) throws Exception {
     if (args.length != 1) {
       throw new IllegalArgumentException("Expected exactly one argument, the URL to GET");
     }
+
+    // Prepare the HTTP GET request
     URL url = new URL(args[0]);
     HttpURLConnection con = (HttpURLConnection) url.openConnection();
     con.setRequestMethod("GET");
+
+    // Make the request
     int status = con.getResponseCode();
+
+    // Exit with a failure code if the GET is not a success
     if (status != 200) {
       System.exit(1);
     }

--- a/rm-services.yml
+++ b/rm-services.yml
@@ -47,8 +47,10 @@ services:
       - UACSERVICE_CONNECTION_HOST=${UAC_HOST}
       - UACSERVICE_CONNECTION_PORT=${UAC_PORT}
     restart: always
+    volumes:
+      - ./java_healthcheck:/opt/healthcheck/
     healthcheck:
-      test: [ "CMD", "curl", "-f", "http://localhost:8161/actuator/health" ]
+      test: [ "CMD", "java", "/opt/healthcheck/HealthCheck.java", "http://localhost:8161/actuator/health" ]
       interval: 60s
       timeout: 10s
       retries: 4
@@ -68,8 +70,10 @@ services:
       - SPRING_DATASOURCE_USERNAME=${POSTGRES_USERNAME}
       - SPRING_DATASOURCE_PASSWORD=${POSTGRES_PASSWORD}
     restart: always
+    volumes:
+      - ./java_healthcheck:/opt/healthcheck/
     healthcheck:
-      test: [ "CMD", "curl", "-f", "http://localhost:8164/actuator/health" ]
+      test: [ "CMD", "java", "/opt/healthcheck/HealthCheck.java", "http://localhost:8164/actuator/health" ]
       interval: 60s
       timeout: 10s
       retries: 4
@@ -86,8 +90,10 @@ services:
       - SPRING_DATASOURCE_URL=jdbc:postgresql://postgres:${POSTGRES_PORT}/${POSTGRES_HOST}?sslmode=disable
       - SPRING_DATASOURCE_USERNAME=${POSTGRES_USERNAME}
       - SPRING_DATASOURCE_PASSWORD=${POSTGRES_PASSWORD}
+    volumes:
+      - ./java_healthcheck:/opt/healthcheck/
     healthcheck:
-      test: [ "CMD", "curl", "-f", "http://localhost:8666/actuator/health" ]
+      test: [ "CMD", "java", "/opt/healthcheck/HealthCheck.java", "http://localhost:8666/actuator/health" ]
       interval: 60s
       timeout: 10s
       retries: 4
@@ -113,7 +119,6 @@ services:
       - DB_DATABASE=${POSTGRES_DATABASE}
       - FILE_UPLOAD_DESTINATION=/home/export-file-service/export_files
       - FILE_UPLOAD_MODE=LOCAL
-
     restart: always
     healthcheck:
       test: sh -c "[ -f /tmp/ready ]"
@@ -151,12 +156,13 @@ services:
       - RAS-RM-SAMPLE-SERVICE_CONNECTION_HOST=host.docker.internal
     restart: always
     healthcheck:
-      test: [ "CMD", "curl", "-f", "http://localhost:9999/actuator/health" ]
+      test: [ "CMD", "java", "/opt/healthcheck/HealthCheck.java", "http://localhost:9999/actuator/health" ]
       interval: 60s
       timeout: 10s
       retries: 4
       start_period: 50s
     volumes:
+      - ./java_healthcheck:/opt/healthcheck/
       - ./dummy_destination_config.json:/home/supporttool/dummy_destination_config.json
 
   rops:
@@ -175,12 +181,13 @@ services:
       - EXPORTFILEDESTINATIONCONFIGFILE=/home/response-operations/dummy_destination_config.json
     restart: always
     healthcheck:
-      test: [ "CMD", "curl", "-f", "http://localhost:7777/actuator/health" ]
+      test: [ "CMD", "java", "/opt/healthcheck/HealthCheck.java", "http://localhost:7777/actuator/health" ]
       interval: 60s
       timeout: 10s
       retries: 4
       start_period: 50s
     volumes:
+      - ./java_healthcheck:/opt/healthcheck/
       - ./dummy_destination_config.json:/home/response-operations/dummy_destination_config.json
 
   notifyservice:
@@ -203,8 +210,10 @@ services:
       - EXCEPTIONMANAGER_CONNECTION_PORT=${EXCEPTIONMANAGER_PORT}
       - NOTIFY_BASEURL=${NOTIFY_STUB_BASEURL}
     restart: always
+    volumes:
+      - ./java_healthcheck:/opt/healthcheck/
     healthcheck:
-      test: [ "CMD", "curl", "-f", "http://localhost:8162/actuator/health" ]
+      test: [ "CMD", "java", "/opt/healthcheck/HealthCheck.java", "http://localhost:8162/actuator/health" ]
       interval: 60s
       timeout: 10s
       retries: 4


### PR DESCRIPTION
# Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
The current API health checks on the Java services use `curl`, requiring it to be installed in the docker images. This PR seeks to remove that dependency so that the docker images need not contain anything non-essential to the service itself by  performing the health check API call with a Java script. The script is mounted into each of the required containers in the docker-compose file and can then be called for the container healthcheck.

# What has changed
<!--- What code changes has been made -->
<!--- Has there been any refactoring -->
<!--- What tests have been written -->
- Add Java HealthCheck script
- Mount Java health check script in required containers
- Call the Java health check script instead of curl in the required containers

# How to test?
<!--- Describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc. -->
<!--- Are there any automated tests that mean changes don't need to be manually changed -->
Run `make up`, then use `docker ps` to check the container health reporting. You should see all the effected containers transition from `starting` to `healthy` like normal.

# Links
<!--- Add any links to issues (trello, github issues) -->
<!--- Links to any documentation -->
<!--- Links to any related PRs -->
https://trello.com/c/EK2yClBJ/40-migrate-java-base-docker-image-5