### PR TITLE
update docker rmi command in README to be more targeted

### DIFF
--- a/README.md
+++ b/README.md
@@ -179,7 +179,7 @@ make: *** [up] Error 1
 
 1. Stop docker containers `make down`
 1. Remove containers `docker rm $(docker ps -aq)`
-1. Delete images `docker rmi $(docker images -qa)`
+1. Delete images `docker rmi $(docker images europe-west2-docker.pkg.dev/ssdc-rm-ci/docker/* -qa)`
 1. Pull and run containers `make up`
 
 ### Service not up?


### PR DESCRIPTION
# Motivation and Context
there is a command in the readme that deletes all docker images, this needs to target just the images used in our docker-dev setup as devs might have other docker images running

# What has changed
updated the suggested docker image cleanup command

# How to test?
- run `docker pull busybox`
- run `make pull` to fetch all the docker-dev images
- run the new command and only the docker images use in this docker-dev setup should be removed and the busybox image should still remain
