### PR TITLE
399 notify processor has default dummy values in config

### DIFF
--- a/rm-services.yml
+++ b/rm-services.yml
@@ -154,6 +154,9 @@ services:
       - EXCEPTIONMANAGER_CONNECTION_HOST=${EXCEPTIONMANAGER_HOST}
       - EXCEPTIONMANAGER_CONNECTION_PORT=${EXCEPTIONMANAGER_PORT}
       - RAS-RM-SAMPLE-SERVICE_CONNECTION_HOST=host.docker.internal
+      - NOTIFY_APIKEY=dummykey-ffffffff-ffff-ffff-ffff-ffffffffffff-ffffffff-ffff-ffff-ffff-ffffffffffff
+      - NOTIFY_BASURL=https://dummy-notify:123
+      - NOTIFY_SENDERID=6bf5f8c2-bc4e-4bbc-a855-aa708d5fdfe7
     restart: always
     healthcheck:
       test: [ "CMD", "java", "-jar", "/opt/healthcheck/HealthCheck.jar", "http://localhost:9999/actuator/health" ]

--- a/rm-services.yml
+++ b/rm-services.yml
@@ -208,9 +208,9 @@ services:
       - UACSERVICE_CONNECTION_PORT=${UAC_PORT}
       - EXCEPTIONMANAGER_CONNECTION_HOST=${EXCEPTIONMANAGER_HOST}
       - EXCEPTIONMANAGER_CONNECTION_PORT=${EXCEPTIONMANAGER_PORT}
-      - NOTIFY_BASE-URL=${NOTIFY_STUB_BASEURL}
-      - NOTIFY_API-KEY=dummykey-ffffffff-ffff-ffff-ffff-ffffffffffff-ffffffff-ffff-ffff-ffff-ffffffffffff
-      - NOTIFY_SENDER-ID=6bf5f8c2-bc4e-4bbc-a855-aa708d5fdfe7
+      - NOTIFY_BASEURL=${NOTIFY_STUB_BASEURL}
+      - NOTIFY_APIKEY=dummykey-ffffffff-ffff-ffff-ffff-ffffffffffff-ffffffff-ffff-ffff-ffff-ffffffffffff
+      - NOTIFY_SENDERID=6bf5f8c2-bc4e-4bbc-a855-aa708d5fdfe7
     restart: always
     volumes:
       - ./java_healthcheck:/opt/healthcheck/

--- a/rm-services.yml
+++ b/rm-services.yml
@@ -154,9 +154,6 @@ services:
       - EXCEPTIONMANAGER_CONNECTION_HOST=${EXCEPTIONMANAGER_HOST}
       - EXCEPTIONMANAGER_CONNECTION_PORT=${EXCEPTIONMANAGER_PORT}
       - RAS-RM-SAMPLE-SERVICE_CONNECTION_HOST=host.docker.internal
-      - NOTIFY_APIKEY=dummykey-ffffffff-ffff-ffff-ffff-ffffffffffff-ffffffff-ffff-ffff-ffff-ffffffffffff
-      - NOTIFY_BASURL=https://dummy-notify:123
-      - NOTIFY_SENDERID=6bf5f8c2-bc4e-4bbc-a855-aa708d5fdfe7
     restart: always
     healthcheck:
       test: [ "CMD", "java", "-jar", "/opt/healthcheck/HealthCheck.jar", "http://localhost:9999/actuator/health" ]
@@ -211,7 +208,9 @@ services:
       - UACSERVICE_CONNECTION_PORT=${UAC_PORT}
       - EXCEPTIONMANAGER_CONNECTION_HOST=${EXCEPTIONMANAGER_HOST}
       - EXCEPTIONMANAGER_CONNECTION_PORT=${EXCEPTIONMANAGER_PORT}
-      - NOTIFY_BASEURL=${NOTIFY_STUB_BASEURL}
+      - NOTIFY_BASE-URL=${NOTIFY_STUB_BASEURL}
+      - NOTIFY_API-KEY=dummykey-ffffffff-ffff-ffff-ffff-ffffffffffff-ffffffff-ffff-ffff-ffff-ffffffffffff
+      - NOTIFY_SENDER-ID=6bf5f8c2-bc4e-4bbc-a855-aa708d5fdfe7
     restart: always
     volumes:
       - ./java_healthcheck:/opt/healthcheck/

--- a/rm-services.yml
+++ b/rm-services.yml
@@ -208,9 +208,9 @@ services:
       - UACSERVICE_CONNECTION_PORT=${UAC_PORT}
       - EXCEPTIONMANAGER_CONNECTION_HOST=${EXCEPTIONMANAGER_HOST}
       - EXCEPTIONMANAGER_CONNECTION_PORT=${EXCEPTIONMANAGER_PORT}
-      - NOTIFY_BASEURL=${NOTIFY_STUB_BASEURL}
-      - NOTIFY_APIKEY=dummykey-ffffffff-ffff-ffff-ffff-ffffffffffff-ffffffff-ffff-ffff-ffff-ffffffffffff
-      - NOTIFY_SENDERID=6bf5f8c2-bc4e-4bbc-a855-aa708d5fdfe7
+      - NOTIFY_BASE-URL=${NOTIFY_STUB_BASEURL}
+      - NOTIFY_API-KEY=dummykey-ffffffff-ffff-ffff-ffff-ffffffffffff-ffffffff-ffff-ffff-ffff-ffffffffffff
+      - NOTIFY_SENDER-ID=6bf5f8c2-bc4e-4bbc-a855-aa708d5fdfe7
     restart: always
     volumes:
       - ./java_healthcheck:/opt/healthcheck/


### PR DESCRIPTION
# Motivation and Context
sets up notify values

# What has changed
Added some that are removed from default notify and need setting here

# How to test?
With notify installed from ticket, run the ATs (main)

# Links
https://trello.com/b/VS0ZyRmj/srm