### PR TITLE
Remove Mock Services from docker-dev

### DIFF
--- a/rm-dependencies.yml
+++ b/rm-dependencies.yml
@@ -59,12 +59,6 @@ services:
     ports:
       - "6379:6379"
 
-  mock-service:
-    container_name: mock-service
-    image: europe-west2-docker.pkg.dev/ons-ci-int/int-docker-release/mock-service:latest
-    ports:
-      - "8163:8162"
-
 networks:
   ssdcrmdockerdev_default:
     external: true


### PR DESCRIPTION
# Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
The old integrations team project got removed on Friday and we still have the Mock-services container trying to pull it's image from there. This is just to remove the container as we don't use it.

# What has changed
<!--- What code changes has been made -->
<!--- Has there been any refactoring -->
<!--- What tests have been written -->
- Remove Mock-services container from docker-dev
# How to test?
<!--- Describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc. -->
<!--- Are there any automated tests that mean changes don't need to be manually changed -->
- Do a make pull/make up and make sure everything comes up correctly.

# Links
<!--- Add any links to issues (trello, github issues) -->
<!--- Links to any documentation -->
<!--- Links to any related PRs -->
[Trello](https://trello.com/c/4ANhQo7H/)
