### PR TITLE
1043 govnotify create an additional service

### DIFF
--- a/dummy-notify-config.json
+++ b/dummy-notify-config.json
@@ -1,0 +1,12 @@
+{
+  "wcis-service": {
+    "base-url": "http://notifystub:5000",
+    "api-key": "dummykey-ffffffff-ffff-ffff-ffff-ffffffffffff-ffffffff-ffff-ffff-ffff-ffffffffffff",
+    "sender-id":" 6bf5f8c2-bc4e-4bbc-a855-aa708d5fdfe7"
+  },
+  "test-service": {
+    "base-url": "http://notifystub:5000",
+    "api-key": "TESTSERVICEKEY-ffffffff-ffff-ffff-ffff-ffffffffffff-ffffffff-ffff-ffff-ffff-ffffffffffff",
+    "sender-id":" 6bf5f8c2-bc4e-4bbc-a855-aa708d5fdfe8"
+  }
+}

--- a/dummy-notify-config.json
+++ b/dummy-notify-config.json
@@ -1,10 +1,10 @@
 {
-  "wcis-service": {
+  "Office_for_National_Statistics_surveys_UKHSA": {
     "base-url": "http://notifystub:5000",
     "api-key": "dummykey-ffffffff-ffff-ffff-ffff-ffffffffffff-ffffffff-ffff-ffff-ffff-ffffffffffff",
     "sender-id":" 6bf5f8c2-bc4e-4bbc-a855-aa708d5fdfe7"
   },
-  "test-service": {
+  "test_service": {
     "base-url": "http://notifystub:5000",
     "api-key": "TESTSERVICEKEY-ffffffff-ffff-ffff-ffff-ffffffffffff-ffffffff-ffff-ffff-ffff-ffffffffffff",
     "sender-id":" 6bf5f8c2-bc4e-4bbc-a855-aa708d5fdfe8"

--- a/rm-services.yml
+++ b/rm-services.yml
@@ -149,6 +149,7 @@ services:
       - DUMMYUSERIDENTITY=${DUMMY_USER}
       - DUMMYUSERIDENTITY-ALLOWED=true
       - EXPORTFILEDESTINATIONCONFIGFILE=/home/supporttool/dummy_destination_config.json
+      - NOTIFYSERVICECONFIGFILE=/home/supporttool/dummy-notify-config.json
       - EXCEPTIONMANAGER_CONNECTION_HOST=${EXCEPTIONMANAGER_HOST}
       - EXCEPTIONMANAGER_CONNECTION_PORT=${EXCEPTIONMANAGER_PORT}
     restart: always
@@ -161,6 +162,7 @@ services:
     volumes:
       - ./java_healthcheck:/opt/healthcheck/
       - ./dummy_destination_config.json:/home/supporttool/dummy_destination_config.json
+      - ./dummy-notify-config.json:/home/supporttool/dummy-notify-config.json
 
   rops:
     container_name: rops

--- a/rm-services.yml
+++ b/rm-services.yml
@@ -203,21 +203,22 @@ services:
       - SPRING_DATASOURCE_PASSWORD=${POSTGRES_PASSWORD}
       - UACSERVICE_CONNECTION_HOST=${UAC_HOST}
       - UACSERVICE_CONNECTION_PORT=${UAC_PORT}
+      - NOTIFYSERVICECONFIGFILE=/home/notifyservice/dummy-notify-config.json
       - EXCEPTIONMANAGER_CONNECTION_HOST=${EXCEPTIONMANAGER_HOST}
       - EXCEPTIONMANAGER_CONNECTION_PORT=${EXCEPTIONMANAGER_PORT}
-      - NOTIFY_BASE-URL=${NOTIFY_STUB_BASEURL}
-      - NOTIFY_API-KEY=dummykey-ffffffff-ffff-ffff-ffff-ffffffffffff-ffffffff-ffff-ffff-ffff-ffffffffffff
-      - NOTIFY_SENDER-ID=6bf5f8c2-bc4e-4bbc-a855-aa708d5fdfe7
+
       - MESSAGELOGGING_LOGSTACKTRACES=true
     restart: always
     volumes:
       - ./java_healthcheck:/opt/healthcheck/
+      - ./dummy-notify-config.json:/home/notifyservice/dummy-notify-config.json
     healthcheck:
       test: [ "CMD", "java", "-jar", "/opt/healthcheck/HealthCheck.jar", "http://localhost:8162/actuator/health" ]
       interval: 60s
       timeout: 10s
       retries: 4
       start_period: 50s
+
 
   jobprocessor:
     container_name: jobprocessor


### PR DESCRIPTION
# Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
At the moment the Gov Notify service we currently use has UKHSA branding on it which means we can't use it if we needed to onboard another survey. This PR adds the functionality to be able to supply multiple gov notify services by adding them to a json file which can be passed in.

# What has changed
<!--- What code changes has been made -->
<!--- Has there been any refactoring -->
<!--- What tests have been written -->
- Added gov notify service config to notify-service and support tool 
# How to test?
<!--- Describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc. -->
<!--- Are there any automated tests that mean changes don't need to be manually changed -->
- Run with the other branches on the card and make sure it all works as expected
- Update the ddl with the ddl branch
- In support tool, create a email and sms template and try creating some with different services.
# Links
<!--- Add any links to issues (trello, github issues) -->
<!--- Links to any documentation -->
<!--- Links to any related PRs -->
[Trello](https://trello.com/c/gL7KBQtj/)
