### PR TITLE
SDCSRM-441-HMS-update-dummy-notify-config

### DIFF
--- a/dummy-notify-config.json
+++ b/dummy-notify-config.json
@@ -1,5 +1,5 @@
 {
-  "Office_for_National_Statistics_surveys_UKHSA": {
+  "Office_for_National_Statistics_surveys_NHS": {
     "base-url": "http://notifystub:5000",
     "api-key": "dummykey-ffffffff-ffff-ffff-ffff-ffffffffffff-ffffffff-ffff-ffff-ffff-ffffffffffff",
     "sender-id":" 6bf5f8c2-bc4e-4bbc-a855-aa708d5fdfe7"


### PR DESCRIPTION
# Motivation and Context
When updating ddl, the notify ref was changed, so to save changing the dummy values later, I've changed them here

# What has changed
Changed the notify ref in dummy-notifty-config

# How to test?
Check it looks ok

# Links
[SDCSRM-441](https://jira.ons.gov.uk/browse/SDCSRM-441)
[DDL PR](https://github.com/ONSdigital/ssdc-rm-ddl/pull/200)

# Screenshots (if appropriate):