### PR TITLE
Disable Flask Debug in Support Frontend Docker container

### DIFF
--- a/rm-services.yml
+++ b/rm-services.yml
@@ -315,6 +315,7 @@ services:
       - APP_CONFIG=DevelopmentConfig
       - PORT=${SUPPORT_FRONTEND_PORT}
       - SUPPORT_API_URL=http://support-api:9095
+      - DEBUG=False
     ports:
       - "${SUPPORT_FRONTEND_PORT}:9096"
     healthcheck:


### PR DESCRIPTION
# Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
When DEBUG is set to true, it doesn't show the internal error pages we expect and the Flask debugger doesn't appear to work as expected. We can set it to False so we can see the internal server error pages we expect to see.
# What has changed
<!--- What code changes has been made -->
<!--- Has there been any refactoring -->
<!--- What tests have been written -->
- Set DEBUG to False in support-frontend
# How to test?
<!--- Describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc. -->
<!--- Are there any automated tests that mean changes don't need to be manually changed -->
- Build the SDCSRM-545-create-survey-details-view branch in support-frontend
- make up in docker-dev
- stop the support-api
- When loading localhost:9096/surveys/, you should see the internal error page appear
# Links
<!--- Add any links to issues (trello, github issues) -->
<!--- Links to any documentation -->
<!--- Links to any related PRs -->
[Jira](https://jira.ons.gov.uk/browse/SDCSRM-545)
