### PR TITLE
SDCSRM-1092 Add PubSub to Support API

### DIFF
--- a/rm-services.yml
+++ b/rm-services.yml
@@ -315,6 +315,8 @@ services:
       - POSTGRES_PASSWORD=${POSTGRES_PASSWORD}
       - SQLALCHEMY_DATABASE_URI=postgresql+psycopg2://${POSTGRES_USERNAME}:${POSTGRES_PASSWORD}@${POSTGRES_HOST}:${POSTGRES_PORT}/${POSTGRES_DATABASE}
       - LOCAL_SAMPLE_FILES_PATH=/home/support-api/sample_files
+      - PUBSUB_EMULATOR_HOST=pubsub-emulator:8538
+      - PROJECT_ID=our-project
     ports:
       - "${SUPPORT_API_PORT}:9095"
     healthcheck:


### PR DESCRIPTION
# Motivation and Context
There was a bug where if you were to create a collection exercise in the new srm-support no entries would be made to the rh firestore.

# What has changed
Added two env variables to srm-support-api container so it will work with the pubsub emulator.

# How to test?
1) Build the Support API card (https://github.com/ONSdigital/srm-support-api/pull/38)
2) Run `make up` on this branch
3) Create a Survey and collection exercise in the support frontend
4) Check the logs of the support-api container and check there's no warnings to do with pubsub (you should see something like "Published message to event_collection-exercise-update")

# Links
https://officefornationalstatistics.atlassian.net/browse/SDCSRM-1092
[Support API PR](https://github.com/ONSdigital/srm-support-api/pull/38)

# Screenshots (if appropriate):