### PR TITLE
SDCSRM-1114 Remove all metions of Response Ops

### DIFF
--- a/.env
+++ b/.env
@@ -44,9 +44,6 @@ CASEREFGENERATORKEY=lOpnY+IDq10Sts/D6kVRPFpZ+y7X+86H
 # Dummy user for RBAC testing
 DUMMY_USER=dummy@fake-email.com
 
-# Response Operations UI/API
-ROPS_PORT=7777
-
 # Export file service
 PLATFORM=LOCAL
 EXPORT_FILE_LOCATION=/export_files

--- a/checkout_and_build_pr.sh
+++ b/checkout_and_build_pr.sh
@@ -199,9 +199,6 @@ checkout_and_build_repo_branch "ssdc-rm-export-file-service" "$BRANCH_NAME" true
 # Support Tool
 checkout_and_build_repo_branch "ssdc-rm-support-tool" "$BRANCH_NAME" true
 
-# ROPS
-checkout_and_build_repo_branch "ssdc-rm-response-operations" "$BRANCH_NAME" true
-
 #Qid Service
 checkout_and_build_repo_branch "ssdc-rm-uac-qid-service" "$BRANCH_NAME" true
 


### PR DESCRIPTION
# Motivation and Context
Response ops is no longer being used, so it's to be archived and removed from other repos.

# What has changed
Removed any mentions of reponse ops

# How to test?
- Check docker dev still runs as expected

# Links
[Jira SDCSRM-1114](https://officefornationalstatistics.atlassian.net/browse/SDCSRM-1114)

# Screenshots (if appropriate):