### PR TITLE
SDCSRM-1527 Bump Github actions for Node 24

### DIFF
--- a/.github/workflows/mega-linter.yml
+++ b/.github/workflows/mega-linter.yml
@@ -32,7 +32,7 @@ jobs:
     steps:
       # Git Checkout
       - name: Checkout Code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           token: ${{ secrets.PAT || secrets.GITHUB_TOKEN }}
 


### PR DESCRIPTION
# Motivation and Context
GitHub Actions are removing support for node 20, so we need to bump our actions so they are compatible with Node 24


# What has changed
Bumped github actions

# How to test?
Check the actions run on this PR and there are no warnings

# Links
[SDCSRM-1527](https://officefornationalstatistics.atlassian.net/browse/SDCSRM-1527)

# Screenshots (if appropriate):